### PR TITLE
Feat output to stdout by default

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -10,6 +10,7 @@ pub fn get_args<'a>() -> clap::ArgMatches<'a> {
         .short("n")
         .long("name")
         .value_name("NAME")
+        .default_value("")
         .help("set the junit suite name. This is also the file name");
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,15 @@ fn main() {
         }
     }
 
-    let mut f =
-        fs::File::create(format!("{}", name)).expect(&format!("could not create file: {}", name));
-
-    format_document(&d, &mut f)
-        .ok()
-        .expect(&format!("unable to output XML to {}", name));
+    if name == "" {
+        format_document(&d, &mut std::io::stdout())
+            .ok()
+            .expect(&format!("unable to output XML to {}", name));
+    } else {
+        let mut f =
+            fs::File::create(format!("{}", name)).expect(&format!("could not create file: {}", name));
+            format_document(&d, &mut f)
+                .ok()
+                .expect(&format!("unable to output XML to {}", name));
+    }
 }


### PR DESCRIPTION
Add a feature such that If no file is specified where to output the resulting xml, output the result to the stdout.

This is useful when calling this tool from another app, which reads the output and further parses it.